### PR TITLE
Wrong way to handle Single Event (Insert Response) Bug Fixed

### DIFF
--- a/app/src/main/java/com/atilsamancioglu/artbookhilttesting/util/Event.kt
+++ b/app/src/main/java/com/atilsamancioglu/artbookhilttesting/util/Event.kt
@@ -1,0 +1,29 @@
+package com.atilsamancioglu.artbookhilttesting.util
+
+import androidx.annotation.Nullable
+
+/**
+ * Used as a wrapper for data that is exposed via a LiveData that represents an event.
+ */
+class Event<T>(content: T?) {
+    private val mContent: T
+    private var hasBeenHandled = false
+
+    @get:Nullable
+    val contentIfNotHandled: T?
+        get() = if (hasBeenHandled) {
+            null
+        } else {
+            hasBeenHandled = true
+            mContent
+        }
+
+    fun hasBeenHandled(): Boolean {
+        return hasBeenHandled
+    }
+
+    init {
+        requireNotNull(content) { "null values in Event are not allowed." }
+        mContent = content
+    }
+}

--- a/app/src/main/java/com/atilsamancioglu/artbookhilttesting/view/ArtDetailsFragment.kt
+++ b/app/src/main/java/com/atilsamancioglu/artbookhilttesting/view/ArtDetailsFragment.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class ArtDetailsFragment @Inject constructor(
-        val glide : RequestManager
+    val glide : RequestManager
 ) : Fragment(R.layout.fragment_art_details) {
     lateinit var viewModel : ArtViewModel
 
@@ -52,8 +52,8 @@ class ArtDetailsFragment @Inject constructor(
 
         binding.saveButton.setOnClickListener {
             viewModel.makeArt(binding.nameText.text.toString(),
-                    binding.artistText.text.toString(),
-                    binding.yearText.text.toString())
+                binding.artistText.text.toString(),
+                binding.yearText.text.toString())
 
         }
 
@@ -66,20 +66,22 @@ class ArtDetailsFragment @Inject constructor(
             }
         })
 
-        viewModel.insertArtMessage.observe(viewLifecycleOwner, Observer {
-            when (it.status) {
-                Status.SUCCESS -> {
-                    Toast.makeText(requireActivity(),"Success",Toast.LENGTH_LONG).show()
-                    findNavController().navigateUp()
-                    viewModel.resetInsertArtMsg()
-                }
+        viewModel.insertArtMessage.observe(viewLifecycleOwner, Observer {event->
+            event.contentIfNotHandled?.let {
+                when (it.status) {
+                    Status.SUCCESS -> {
+                        Toast.makeText(requireActivity(),"Success",Toast.LENGTH_LONG).show()
+                        findNavController().navigateUp()
+                        viewModel.resetInsertArtMsg()
+                    }
 
-                Status.ERROR -> {
-                    Toast.makeText(requireContext(),it.message ?: "Error",Toast.LENGTH_LONG).show()
-                }
+                    Status.ERROR -> {
+                        Toast.makeText(requireContext(),it.message ?: "Error",Toast.LENGTH_LONG).show()
+                    }
 
-                Status.LOADING -> {
+                    Status.LOADING -> {
 
+                    }
                 }
             }
         })

--- a/app/src/main/java/com/atilsamancioglu/artbookhilttesting/viewmodel/ArtViewModel.kt
+++ b/app/src/main/java/com/atilsamancioglu/artbookhilttesting/viewmodel/ArtViewModel.kt
@@ -8,13 +8,14 @@ import androidx.lifecycle.viewModelScope
 import com.atilsamancioglu.artbookhilttesting.model.ImageResponse
 import com.atilsamancioglu.artbookhilttesting.repo.ArtRepositoryInterface
 import com.atilsamancioglu.artbookhilttesting.roomdb.Art
+import com.atilsamancioglu.artbookhilttesting.util.Event
 import com.atilsamancioglu.artbookhilttesting.util.Resource
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.whileSelect
 import java.lang.Exception
 
 class ArtViewModel @ViewModelInject constructor(
-        private val repository : ArtRepositoryInterface
+    private val repository : ArtRepositoryInterface
 ) : ViewModel() {
 
     val artList = repository.getArt()
@@ -27,13 +28,13 @@ class ArtViewModel @ViewModelInject constructor(
     val selectedImageUrl : LiveData<String>
         get() = selectedImage
 
-    private var insertArtMsg = MutableLiveData<Resource<Art>>()
-    val insertArtMessage : LiveData<Resource<Art>>
+    private var insertArtMsg = MutableLiveData<Event<Resource<Art>>>()
+    val insertArtMessage : LiveData<Event<Resource<Art>>>
         get() = insertArtMsg
 
     //Solving the navigation bug
     fun resetInsertArtMsg() {
-        insertArtMsg = MutableLiveData<Resource<Art>>()
+        insertArtMsg = MutableLiveData<Event<Resource<Art>>>()
     }
 
     fun setSelectedImage(url : String) {
@@ -50,20 +51,20 @@ class ArtViewModel @ViewModelInject constructor(
 
     fun makeArt(name : String, artistName : String, year : String) {
         if (name.isEmpty() || artistName.isEmpty() || year.isEmpty() ) {
-            insertArtMsg.postValue(Resource.error("Enter name, artist, year", null))
+            insertArtMsg.postValue(Event(Resource.error("Enter name, artist, year", null)))
             return
         }
         val yearInt = try {
             year.toInt()
         } catch (e: Exception) {
-            insertArtMsg.postValue(Resource.error("Year should be number",null))
+            insertArtMsg.postValue(Event(Resource.error("Year should be number",null)))
             return
         }
 
         val art = Art(name, artistName, yearInt,selectedImage.value?: "")
         insertArt(art)
         setSelectedImage("")
-        insertArtMsg.postValue(Resource.success(art))
+        insertArtMsg.postValue(Event(Resource.success(art)))
     }
 
     fun searchForImage (searchString : String) {


### PR DESCRIPTION

https://user-images.githubusercontent.com/30105033/132323276-b7e905b3-5da2-44c6-935f-9a570e02fbd0.mp4

this video show now the insert response observers only will observe if the button is clicked

I have added Event class  and handle the single events like showing toast , snackbar without observing changes again and again.